### PR TITLE
docs: add ADR-001 inference engine decision

### DIFF
--- a/docs/adr/ADR-001-inference-engine.md
+++ b/docs/adr/ADR-001-inference-engine.md
@@ -1,0 +1,24 @@
+# ADR-001 — Inference Engine
+
+**Status:** Accepted  
+**Date:** 2026-03-13
+
+## Decision
+
+Use Ollama running llama3.1:70b on the Mac Studio M3 as the local inference engine.
+
+## Reasoning
+
+- Runs entirely offline on the home network
+- 96GB unified memory supports the 70b model comfortably
+- Ollama provides a simple REST API that Flask can call directly
+- No cloud costs or data leaving the network
+
+## Alternatives considered
+
+- Raspberry Pi 5 with a smaller model — rejected, too slow (3–5 tokens/second)
+- Cloud API (OpenAI, Anthropic) — rejected, defeats the local-first goal
+
+## Consequences
+
+All features must be designed around local inference latency. Complex multi-step reasoning tasks will be slower than cloud alternatives.


### PR DESCRIPTION
## What this does
Adds the first Architecture Decision Record documenting the choice of 
Ollama + llama3.1:70b on the Mac Studio M3 as the local inference engine.

## Why
Establishes the ADR process and documents the core infrastructure decision 
that all other Osiris features are built on top of.

## Testing
No code changes — documentation only.