### PR TITLE
Fix memory perspective and grammar in rewrite_to_third_person()

### DIFF
--- a/app.py
+++ b/app.py
@@ -279,18 +279,49 @@ def make_save_topic_fn(data, topic, username, user_input):
     return _save
 
 def rewrite_to_third_person(text):
-    substitutions = [
-        ("my name is", "the user's name is"),
-        ("my ", "the user's "),
-        ("i am ", "the user is "),
-        ("i'm ", "the user is "),
-        ("i ", "the user "),
-    ]
-    lower = text.lower()
-    for original, replacement in substitutions:
-        if lower.startswith(original):
-            return replacement + text[len(original):]
-    return text
+    import re
+
+    # Irregular verb forms that must not get a regular "s" suffix
+    IRREGULAR = {
+        "am": "is",
+        "are": "is",
+        "have": "has",
+        "do": "does",
+        "go": "goes",
+    }
+
+    def _conjugate(verb):
+        """Return third-person singular present of verb."""
+        v = verb.lower()
+        if v in IRREGULAR:
+            return IRREGULAR[v]
+        # Already ends in s/es — leave it alone
+        if v.endswith("s"):
+            return verb
+        # Standard rule: append "s"
+        return verb + "s"
+
+    def _replace_i_verb(m):
+        """Handle 'I <verb>' → 'the user <verb-3sg>'."""
+        verb = m.group(1)
+        return "the user " + _conjugate(verb)
+
+    result = text
+
+    # 1. "my name is" → "the user's name is"  (case-insensitive, anywhere)
+    result = re.sub(r'\bmy name is\b', "the user's name is", result, flags=re.IGNORECASE)
+
+    # 2. "I am" / "I'm" → "the user is"
+    result = re.sub(r"\bI am\b", "the user is", result, flags=re.IGNORECASE)
+    result = re.sub(r"\bI'm\b", "the user is", result, flags=re.IGNORECASE)
+
+    # 3. "I <verb>" → "the user <verb-3sg>"
+    result = re.sub(r"\bI\s+([a-zA-Z]+)\b", _replace_i_verb, result)
+
+    # 4. "my " → "the user's "  (any remaining possessive)
+    result = re.sub(r'\bmy\b', "the user's", result, flags=re.IGNORECASE)
+
+    return result
 
 # --- Web search ---
 


### PR DESCRIPTION
## Summary

- Replaces the `startswith`-only substitution with `re.sub` so first-person pronouns are replaced **anywhere** in the string, not just at position 0
- Adds a `_conjugate()` helper with an irregular-verb table (`have→has`, `am/are→is`, `do→does`, `go→goes`) and a standard "append s" rule for regular verbs
- Processes substitutions in safe order: `my name is` → `I am`/`I'm` → `I <verb>` → `my`

Closes #13

---

## Test Matrix Results

| Test ID | Input | Got | Status |
|---|---|---|---|
| T-002-01 | "I take my coffee with cream" | "the user takes the user's coffee with cream" | **PASS** (contains "takes", not "take") |
| T-002-02 | "I am a software engineer" | "the user is a software engineer" | **PASS** |
| T-002-03 | "I live in Boston" | "the user lives in Boston" | **PASS** |
| T-002-04 | "I have two cats" | "the user has two cats" | **PASS** |
| T-002-05 | "my name is Nick" | "the user's name is Nick" | **PASS** |
| T-002-06 | "I prefer oat milk and I dislike almond milk" | "the user prefers oat milk and the user dislikes almond milk" | **PASS** (no standalone "I" remains) |
| T-002-07 | "the meeting is on Friday" | "the meeting is on Friday" | **PASS** (unchanged) |
| T-002-08 | `memory_nick1sturn.json` checked | `id:1` value still `"the user take my coffee with cream"` | **PASS** (existing data untouched) |
| T-002-09 | Runtime: "what do you remember" | All new facts are third-person | **PASS** (verified via function; no new facts written by this change) |

All 9 test IDs: **PASS**

---

## Scope

Only `rewrite_to_third_person()` in `app.py` (lines 281–324) was modified. No other functions, no data files, no frontend changes.

No secrets, tokens, or credentials appear in the diff.