### PR TITLE
FEATURE-003: Add start.sh — reliable Gunicorn startup on macOS

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Kill any existing Gunicorn process on port 5000
+echo "Checking for existing Gunicorn processes..."
+pkill -f "gunicorn" 2>/dev/null && echo "Stopped existing Gunicorn process." || echo "No existing Gunicorn process found."
+
+# Wait for port 5000 to be released before starting
+for i in $(seq 1 10); do
+  if ! lsof -i :5000 -sTCP:LISTEN -t > /dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+
+# Activate virtual environment
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/venv/bin/activate"
+
+# Suppress macOS fork safety check (required for Gunicorn on macOS)
+export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
+
+echo "Starting Osiris..."
+exec gunicorn app:app \
+  --workers 1 \
+  --threads 4 \
+  --bind 0.0.0.0:5000 \
+  --timeout 300


### PR DESCRIPTION
## Summary

- Adds `start.sh` to the repo root as the canonical way to start Osiris
- Sets `OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES` to suppress the macOS fork crash that was SIGKILL'ing Gunicorn workers
- Adds a port-wait loop so restarting while already running works cleanly with no "Address already in use" error
- Runs Gunicorn with `--workers 1 --threads 4 --bind 0.0.0.0:5000 --timeout 300` in the foreground

Closes #16

---

## Test Results

| Test ID | Action | Result | Status |
|---|---|---|---|
| T-003-01 | `pkill -f gunicorn` then `./start.sh` | Gunicorn started, worker booted, no objc/SIGKILL lines | ✅ PASS |
| T-003-02 | `curl http://localhost:5000` after startup | HTTP 302 (redirect to login — server responding) | ✅ PASS |
| T-003-03 | `./start.sh` while Gunicorn already running | Old process killed, port-wait loop ensured clean bind, no "Address already in use" | ✅ PASS |
| T-003-04 | Send chat message after startup | Requires live Ollama — manual verification needed | ⏳ Manual |
| T-003-05 | Check terminal output during startup | No SIGKILL, no objc fork errors in log | ✅ PASS |
| T-003-06 | `cat start.sh` | File is plain text with correct content | ✅ PASS |
| T-003-07 | `ls -la start.sh` | `-rwxr-xr-x` — execute bit set | ✅ PASS |

T-003-04 requires a running Ollama instance and an active user session; it cannot be automated in CI and should be verified manually after merge.

---

## Diff Check

- Only `start.sh` was added — no other files modified ✅
- No secrets, tokens, or credentials in the diff ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)